### PR TITLE
Update dependency requirement to run qa.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openai
 faiss-cpu
 streamlit
 streamlit-chat
+tiktoken


### PR DESCRIPTION
Unless `tiktoken` is installed you would get this error:

```bash
➜  notion-qa git:(master) ✗ python3 qa.py "who accepted an offer"
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/langchain/llms/openai.py", line 233, in get_num_tokens
    import tiktoken
ModuleNotFoundError: No module named 'tiktoken'
```